### PR TITLE
Ensure a single PR is created for update-pre-commit

### DIFF
--- a/.github/workflows/update_precommit.yml
+++ b/.github/workflows/update_precommit.yml
@@ -46,7 +46,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
-          branch-suffix: random
+          branch: create-pull-request/update-pre-commit
           delete-branch: true
           title: 'Update pre-commit'
           body: |


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Ensure a single PR is created for update-pre-commit.

We don't really need to have a random branch created so lets track on one branch which gets deleted. If a second update is made it'll just get added as a new commit to the branch and be a part of the PR. This way we prevent multiple PRs each day.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Probably not easy but the CI shouldn't create multiple PRs if unmerged. (Probably unlikely to happen again unless we all simultaneously head to RHTE again...)
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #13 

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
