### PR TITLE
Exclude Ansible devel version from being tested using Python 3.9

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -86,6 +86,10 @@ on:
             {
               "ansible-version": "devel",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
             }
           ]
         required: false


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Excludes the testing scenario: Ansible `devel` + Python 3.9

as it's not feasable:
https://github.com/redhat-cop/controller_configuration/actions/runs/5517409942/jobs/10071044253?pr=645

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
N/A
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
N/A
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- resolves #[number] -->

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
