### PR TITLE
Move ansible.cfg if it exists

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -137,6 +137,9 @@ jobs:
           collection_version: ${{ inputs.collection_version }}
           collection_repo: ${{ inputs.collection_repo }}
 
+      - name: Move ansible.cfg if exists
+        run: mv .github/files/ansible.cfg . || echo "Nothing to move"
+
       - name: Print the ansible version
         run: ansible --version
 


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes the problem with the sanity check failing because the ansible.cfg hasn't been copied across.

The issue is seen here:
https://github.com/redhat-cop/controller_configuration/actions/runs/5739481962/job/15555291571

# How should this be tested?
Rerun CI after merge
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
N/A
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
