### PR TITLE
move ansible.cfg step to fix sanity problem

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -122,6 +122,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Move ansible.cfg if exists
+        run: mv .github/files/ansible.cfg . || echo "Nothing to move"
+
       - name: Install ansible-core (${{ matrix.ansible-version }})
         run: python3 -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check
 
@@ -136,9 +139,6 @@ jobs:
           collection_name: ${{ inputs.collection_name }}
           collection_version: ${{ inputs.collection_version }}
           collection_repo: ${{ inputs.collection_repo }}
-
-      - name: Move ansible.cfg if exists
-        run: mv .github/files/ansible.cfg . || echo "Nothing to move"
 
       - name: Print the ansible version
         run: ansible --version


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Move the ansible.cfg move step to prior to the ansible install and collection step, This dictates where it looks for things.

# How should this be tested?
Fixes automated tests
this is the test I ran on it
https://github.com/sean-m-sullivan/controller_configuration/actions/runs/5746079765/job/15575022459

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
