### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/build_ee.yml
+++ b/.github/workflows/build_ee.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
 
       - name: Checkout tooling repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: redhat-cop/ansible_collections_tooling
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/create_changelog.yml
+++ b/.github/workflows/create_changelog.yml
@@ -30,9 +30,9 @@ jobs:
     env:
       ANSIBLE_FORCE_COLOR: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create Pull Request
         id: prcreate
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.token }}
           commit-message: Update changelog ${{ github.ref }}

--- a/.github/workflows/internal-pre-commit.yml
+++ b/.github/workflows/internal-pre-commit.yml
@@ -12,12 +12,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install Ansible
         run: pip install --upgrade ansible-core
         if: inputs.collection_dependencies
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
 ...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,8 +32,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install Ansible
@@ -48,5 +48,5 @@ jobs:
       - name: Install collection dependencies
         run: ansible-galaxy collection install ${{ inputs.collection_dependencies }}
         if: inputs.collection_dependencies
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
 ...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/update_precommit.yml
+++ b/.github/workflows/update_precommit.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       ANSIBLE_FORCE_COLOR: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install pre-commit
         run: pip install --upgrade pre-commit
@@ -26,7 +26,7 @@ jobs:
       - name: Update pre-commit
         run: pre-commit autoupdate
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -35,11 +35,11 @@ jobs:
 
       - name: Run Pre-commit to alert of any linting changes.
         continue-on-error: true
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
       - name: Create Pull Request
         id: prcreate
-        uses: peter-evans/create-pull-request@v4.2.3
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.token }}
           commit-message: Update pre-commit


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

This PR updates the version of several of the GitHub actions that are used in the GitHub workflows. This will fix the actions errors that are occurring due to Node.js 16 being deprecated.

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
