### PR TITLE
fix collection path

### DIFF
--- a/actions/build_ansible_collection/action.yaml
+++ b/actions/build_ansible_collection/action.yaml
@@ -36,7 +36,7 @@ runs:
       working-directory: ${{ inputs.source_path }}
 
     - name: Install collection
-      run: ansible-galaxy collection install . -p /home/runner/collections
+      run: ansible-galaxy collection install .
       shell: bash
       working-directory: ${{ inputs.source_path }}
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
With recent and other changes this is no longer needed, lint is better at picking things up now.
