### PR TITLE
Fix issue where the branch added a timestamp

### DIFF
--- a/.github/workflows/create_changelog_crc.yml
+++ b/.github/workflows/create_changelog_crc.yml
@@ -46,13 +46,14 @@ jobs:
       - name: Run changelog
         run: antsibull-changelog release --verbose --version ${{ inputs.collection_version }}
 
-      - name: Push to changelog-patches branch
+      - name: Push to release branch
+        id: push_changelog
         uses: devops-infra/action-commit-push@master
         with:
           github_token: "${{ secrets.token }}"
-          add_timestamp: true
+          add_timestamp: false
           commit_prefix: "[AUTO]"
-          commit_message: "Update changelog ${{ github.ref }}"
+          commit_message: "Update changelog ${{ inputs.collection_version }}"
           force: false
           target_branch: release/${{ inputs.collection_version }}
 ...


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?

I had taken a sample of the action and missed that it was going to add a timestamp to the branch which caused later failures in finding that branch. This is now removed.

# How should this be tested?

Run release again

# Is there a relevant Issue open for this?
no

# Other Relevant info, PRs, etc
Fixes issue seen here: https://github.com/redhat-cop/infra.aap_configuration/actions/runs/15447123469/job/43479902360
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
