### PR TITLE
FIX - merge_release job not receiving vars

### DIFF
--- a/.github/workflows/release_pipeline_dual_crc.yml
+++ b/.github/workflows/release_pipeline_dual_crc.yml
@@ -210,6 +210,7 @@ jobs:
           ]) == {'success'}"
   merge_release:
     needs:
+      - calculate_version
       - release_check
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
issue was because the calculate_version job was not in the 'needs', meaning that the variable was not accessible under needs.calculate_version
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Release
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
No
<!--- Provide a link to any open issues that describe the problem you are solving. -->


# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
