### PR TITLE
Don't run changelog step if not doing a release

### DIFF
--- a/.github/workflows/release_pipeline_dual_crc.yml
+++ b/.github/workflows/release_pipeline_dual_crc.yml
@@ -143,6 +143,7 @@ jobs:
   changelog:
     needs:
       - calculate_version
+    if: (needs.calculate_version.outputs.change_level != 'major' && needs.calculate_version.outputs.change_present != 'false') || github.event_name == 'workflow_dispatch'
     uses: redhat-cop/ansible_collections_tooling/.github/workflows/create_changelog_crc.yml@main
     with:
       collection_namespace: ${{ inputs.collection_namespace_1 }}


### PR DESCRIPTION
<!--- markdownlint-disable -->
# What does this PR do?
Prevents the changelog step from running when not performing a release. This occurred over the weekend on a repo which had no changes to release. Correctly, no release occurred, but it did still create a release branch with an incremented changelog.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Wait for next scheduled run (a forced run will defy the logic. 

That said, this is the exact same logic used on the other steps, which did work in the CI run.

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #79 

# Other Relevant info, PRs, etc

