### PR TITLE
hard locking ansible-core to be under 2.19 for now

### DIFF
--- a/.github/workflows/build_ee.yml
+++ b/.github/workflows/build_ee.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt -y install podman
 
       - name: Install Ansible and Ansible Builder
-        run: pip install --upgrade setuptools ansible-core ansible-builder
+        run: pip install --upgrade setuptools "ansible-core>=2.15,<2.19" ansible-builder
 
       - name: Move ansible.cfg if exists
         run: mv .github/files/ansible.cfg . || echo "Nothing to move"

--- a/.github/workflows/create_changelog.yml
+++ b/.github/workflows/create_changelog.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Ansible
-        run: pip install --upgrade ansible-core antsibull-changelog
+        run: pip install --upgrade "ansible-core>=2.15,<2.19" antsibull-changelog
 
       - name: template galaxy file (appended version with -devel as this will remain in repo)
         run: ansible all -i 'localhost,' -c local -m template -a "src=.github/files/galaxy.yml.j2 dest=galaxy.yml" --extra-vars "collection_namespace=${{ inputs.collection_namespace }} collection_name=${{ inputs.collection_name }} collection_version=${{ inputs.collection_version }}-devel collection_repo=${{ inputs.collection_repo }}"

--- a/.github/workflows/create_changelog_crc.yml
+++ b/.github/workflows/create_changelog_crc.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Ansible
-        run: pip install --upgrade ansible-core antsibull-changelog
+        run: pip install --upgrade "ansible-core>=2.15,<2.19" antsibull-changelog
 
       - name: template galaxy file (appended version with -devel as this will remain in repo)
         run: ansible all -i 'localhost,' -c local -m template -a "src=.github/files/galaxy.yml.j2 dest=galaxy.yml" --extra-vars "collection_namespace=${{ inputs.collection_namespace }} collection_name=${{ inputs.collection_name }} collection_version=${{ inputs.collection_version }}-devel collection_repo=${{ inputs.collection_repo }}"

--- a/.github/workflows/internal-pre-commit.yml
+++ b/.github/workflows/internal-pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Ansible
-        run: pip install --upgrade ansible-core
+        run: pip install --upgrade "ansible-core>=2.15,<2.19"
         if: inputs.collection_dependencies
       - uses: pre-commit/action@v3.0.1
 ...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Ansible
-        run: pip install --upgrade ansible-core pyyaml==6.0.1
+        run: pip install --upgrade "ansible-core>=2.15,<2.19" pyyaml==6.0.1
       - name: Build and install the collection
         uses: redhat-cop/ansible_collections_tooling/actions/build_ansible_collection@main
         with:

--- a/.github/workflows/pre-commit_crc.yml
+++ b/.github/workflows/pre-commit_crc.yml
@@ -5,6 +5,7 @@ name: pre-commit tests
 
 
 on:
+  pull_request_target:
   workflow_call:
     inputs:
       collection_namespace:

--- a/.github/workflows/pre-commit_crc.yml
+++ b/.github/workflows/pre-commit_crc.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install Ansible
-        run: pip install --upgrade ansible-core pyyaml==6.0.1
+        run: pip install --upgrade "ansible-core>=2.15,<2.19" pyyaml==6.0.1
       - name: Install collection
         run: ansible-galaxy collection install . -vvvv
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         run: mv .github/files/ansible.cfg . || echo "Nothing to move"
 
       - name: Install Ansible
-        run: pip install --upgrade ansible-core
+        run: pip install --upgrade "ansible-core>=2.15,<2.19"
 
       - name: Build and install the collection
         id: build

--- a/.github/workflows/release_crc.yml
+++ b/.github/workflows/release_crc.yml
@@ -66,7 +66,7 @@ jobs:
         run: mv .github/files/ansible.cfg . || echo "Nothing to move"
 
       - name: Install Ansible
-        run: pip install --upgrade ansible-core
+        run: pip install --upgrade "ansible-core>=2.15,<2.19"
 
       - name: Build and install the collection
         id: build

--- a/.github/workflows/update_precommit.yml
+++ b/.github/workflows/update_precommit.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Ansible
-        run: pip install --upgrade ansible-core
+        run: pip install --upgrade "ansible-core>=2.15,<2.19"
 
       - name: Run Pre-commit to alert of any linting changes.
         continue-on-error: true


### PR DESCRIPTION
hard locking ansible-core to be under 2.19 for now because it is breaking CI and will require specific rewrites in places, also found that pre-commit_crc workflow didn't have pull_request_target
