### PR TITLE
Fix CRC pre-commit for fork PRs via Ansible collections cache

### DIFF
--- a/.github/workflows/pre-commit_crc.yml
+++ b/.github/workflows/pre-commit_crc.yml
@@ -1,6 +1,10 @@
 ---
 # This workflow action will run pre-commit, which will execute ansible and yaml linting
 # See .pre-commit-config.yaml for what hooks are executed
+#
+# Fork pull_request runs do not receive Automation Hub secrets. Push/schedule runs
+# (with secrets) populate the Ansible collections cache; fork PRs restore that cache
+# and install offline.
 name: pre-commit tests
 
 
@@ -34,17 +38,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # This tells the action to pull from the branch that created the PR
-          ref: ${{ github.event.pull_request.head.sha }}
-          # This ensures it works even if the PR comes from a fork
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # Prefer PR head (incl. forks); fall back for push/schedule cache warming.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
       - name: Install Ansible
         run: pip install --upgrade "ansible-core>=2.20" pyyaml==6.0.1
+      - name: Cache Ansible collections
+        uses: actions/cache@v4
+        with:
+          path: ~/.ansible/collections
+          key: ansible-collections-${{ runner.os }}-${{ hashFiles('galaxy.yml', '**/requirements*.yml', '**/requirements*.yaml') }}
+          restore-keys: |
+            ansible-collections-${{ runner.os }}-
       - name: Install collection
-        run: ansible-galaxy collection install . -vvvv
+        run: |
+          set -euo pipefail
+          if [ -n "${ANSIBLE_GALAXY_SERVER_PUBLISHED_TOKEN:-}" ]; then
+            ansible-galaxy collection install . -vvvv
+          else
+            echo "No Automation Hub token available (typical for fork pull_request)."
+            echo "Installing from the restored Ansible collections cache (--offline)."
+            if ! ansible-galaxy collection install . --offline -vvvv; then
+              echo "::error::Offline collection install failed. Push/schedule runs must populate the Ansible collections cache (with CRC_PUBLISH_KEY) before fork PRs can use it."
+              exit 1
+            fi
+          fi
         shell: bash
         env:
           ANSIBLE_GALAXY_SERVER_VALIDATED_URL: 'https://console.redhat.com/api/automation-hub/content/validated/'


### PR DESCRIPTION
## Summary
- Cache `~/.ansible/collections` in `pre-commit_crc.yml` so fork `pull_request` runs can reuse dependencies installed by push/schedule.
- When `ansible_ah_token` is empty (fork PRs cannot access secrets), install with `--offline` instead of failing against Automation Hub / Galaxy.
- Fix checkout ref/repository fallbacks for push/schedule cache-warming runs.

## Why
Fork PRs for collections that depend on `redhat.*` (e.g. `infra.satellite_configuration` → `redhat.satellite`) fail at **Install collection** because `CRC_PUBLISH_KEY` is unavailable on `pull_request` from forks. Same-repo PRs work because secrets are present.

Related failure: https://github.com/redhat-cop/infra.satellite_configuration/actions/runs/29575630620/job/87869498512
Working same-repo PR: https://github.com/redhat-cop/infra.satellite_configuration/actions/runs/29575972360/job/87871191322

## Test plan
- [ ] Merge this PR, then run a `push`/`schedule` on a CRC collection repo that uses `pre_commit_workflow_crc.yml` (with `CRC_PUBLISH_KEY`) to populate the collections cache.
- [ ] Re-run a fork PR pre-commit job and confirm **Install collection** uses offline/cache and succeeds.
- [ ] Confirm same-repo PRs / pushes still install online with the AH token.


Made with [Cursor](https://cursor.com)